### PR TITLE
1 bug compilation failure with fallthrough attribute

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = .
 
 SOURCE_FILES = libcfg.c
 
-AM_CPPFLAGS = -I$(top_srcdir) -Wall -Werror -Wshadow -Wduplicated-cond -Wunused-parameter -fstack-protector
+AM_CPPFLAGS = -I$(top_srcdir) -Wall -Werror -Wshadow -Wduplicated-cond -Wunused-parameter -fstack-protector -Wimplicit-fallthrough=0
 
 if ENABLE_COVERAGE
 AM_CPPFLAGS += --coverage

--- a/src/libcfg.c
+++ b/src/libcfg.c
@@ -830,7 +830,7 @@ static cfg_parse_return_t cfg_parse_line(char *line, const size_t len,
       return CFG_PARSE_PASS;
     case CFG_PARSE_ARRAY_NEWLINE:
       *newline = ' ';
-#if __STDC_VERSION__ > 201112L
+#if __STDC_VERSION__ > 201710L
       [[fallthrough]];
 #endif
     case CFG_PARSE_CLEAN:
@@ -1436,7 +1436,7 @@ int cfg_read_file(cfg_t *cfg, const char *fname, const int prior) {
         case CFG_PARSE_ERROR:
           sprintf(msg, "%zu", nline);
           cfg_msg(cfg, "invalid configuration entry at line", msg);
-#if __STDC_VERSION__ > 201112L
+#if __STDC_VERSION__ > 201710L
           [[fallthrough]];
 #endif
         case CFG_PARSE_PASS:


### PR DESCRIPTION
https://github.com/P1sec/libcfg/issues/1

```txt
      :::    :::     :::     :::::::::  :::::::::  :::   ::: 
     :+:    :+:   :+: :+:   :+:    :+: :+:    :+: :+:   :+:  
    +:+    +:+  +:+   +:+  +:+    +:+ +:+    +:+  +:+ +:+    
   +#++:++#++ +#++:++#++: +#++:++#+  +#++:++#+    +#++:      
  +#+    +#+ +#+     +#+ +#+        +#+           +#+        
 #+#    #+# #+#     #+# #+#        #+#           #+#         
###    ### ###     ### ###        ###           ###

      :::::::::: ::::::::::: :::::::::   :::::::: ::::::::::: 
     :+:            :+:     :+:    :+: :+:    :+:    :+:      
    +:+            +:+     +:+    +:+ +:+           +:+       
   :#::+::#       +#+     +#++:++#:  +#++:++#++    +#+        
  +#+            +#+     +#+    +#+        +#+    +#+         
 #+#            #+#     #+#    #+# #+#    #+#    #+#          
###        ########### ###    ###  ########     ###  

      :::::::::  ::::::::: 
     :+:    :+: :+:    :+: 
    +:+    +:+ +:+    +:+  
   +#++:++#+  +#++:++#:    
  +#+        +#+    +#+    
 #+#        #+#    #+#     
###        ###    ###                        
```

